### PR TITLE
引数に絶対パスが入力された場合の対応

### DIFF
--- a/Image2PDF.py
+++ b/Image2PDF.py
@@ -81,7 +81,7 @@ def main():
     quit()
 
 #  pdfFile = canvas.Canvas("./" + keyword + ".pdf")
-  pdfFile = canvas.Canvas("./" + unicode(keyword, 'shift-jis') + ".pdf")  # for Windows
+  pdfFile = canvas.Canvas(unicode(keyword, 'shift-jis') + ".pdf")  # for Windows
   pdf.setparam(pdfFile)
 
   search_path = os.path.normpath("./" + keyword + "/*")


### PR DESCRIPTION
引数に絶対パスが入力された場合、現行ソースでは、"./"が先頭についてしまうので、
正しくパスが入力できません。
相対パスでも"./"は不要ですので、削除しました。
